### PR TITLE
Track kernel cycles, improve PerfEventBlock for multiple threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Basic Usage:
 
-```
+```c++
 #include "PerfEvent.hpp"
 ...
 PerfEvent e;
@@ -23,7 +23,7 @@ cycles, instructions, L1-misses, LLC-misses, branch-misses, task-clock,    scale
 
 ### Usage of PerfEventBlock (convenience wrapper):
 
-```
+```c++
 #include "PerfEvent.hpp"
 
 // Define some global params
@@ -49,13 +49,25 @@ for (int threads=1;threads<maxThreads;++threads) {
 ```
 
 This prints something like this:
-```
+```csv
            name, dataSize, threads, time sec,      cycles, instructions, L1-misses, LLC-misses, branch-misses, task-clock,   scale,      IPC,     CPUs,      GHz
 Dummy Benchmark,   100 GB,       1, 1.400645, 1075.520519,  1931.465504,  8.888315,   0.070063,      0.121389, 280.115649, 5000000, 1.795843, 0.999952, 3.839559
 Dummy Benchmark,   100 GB,       2, 1.133364, 2386.772941,  2062.313141, 32.095011,   0.043248,      0.918986, 650.737357, 5000000, 0.864059, 1.870823, 3.667798
 ...
 ```
 
+Sometimes the measured counters differ depending on when you construct `PerfEvent`, for example before vs. after starting threads.
+You can control this by passing an existing `PerfEvent` instance to `PerfEventBlock`:
+
+``` c++
+PerfEvent perfevent;
+// start threads etc.
+{
+  PerfEventBlock perf(perfevent);
+  yourBenchmark();
+}
+```
+
 ### Troubleshooting
 
-You may need to run "sudo sysctl -w kernel.perf_event_paranoid=-1" and/or add "kernel.perf_event_paranoid = -1" to /etc/sysctl.conf
+You may need to run `sudo sysctl -w kernel.perf_event_paranoid=-1` and/or add `kernel.perf_event_paranoid = -1` to `/etc/sysctl.conf`


### PR DESCRIPTION
## Track kernel cycles
Adds kernel cycles as a default counter to `PerfEvent`.

## Allow passing existing PerfEvent instance into PerfEventBlock
This is sometimes useful when working with threads, for example:

```c++
for (auto rep = 0; rep != 2; ++rep) {
    PerfEventBlock blk;
    tbb::parallel_for(/*...*/);
}
```
outputs different counters for the second measurement because threads are started before it registers the counters:
```csv
time sec,  cycles, instructions, L1-misses, LLC-misses, branch-misses, task-clock,   scale,  IPC,  CPUs,  GHz
    0.07, 9954.69, 18106.04,      0.50,       0.37,          0.38,    2241.61, 1000000, 1.82, 31.46, 4.44
    0.06,  313.36,   569.29,      0.01,       0.01,          0.00,      60.20, 1000000, 1.82,  1.00, 5.21
```

Constructing a `PerfEvent` instance first fixes this:

```c++
PerfEvent perf;
for (auto rep = 0; rep != 2; ++rep) {
    PerfEventBlock blk(perf);
    tbb::parallel_for(/*...*/);
}
```
Output:

```csv
time sec,  cycles, instructions, L1-misses, LLC-misses, branch-misses, task-clock,   scale,  IPC,  CPUs,  GHz
    0.07, 9913.72,     18062.02,      0.44,       0.34,          0.24,    2215.02, 1000000, 1.82, 31.44, 4.48
    0.06, 9914.04,     18022.91,      0.17,       0.11,          0.08,    1911.61, 1000000, 1.82, 31.93, 5.19
```