### PR TITLE
Add Missing sstream Include

### DIFF
--- a/PerfEvent.hpp
+++ b/PerfEvent.hpp
@@ -32,6 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <iomanip>
 #include <iostream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
When building `PerfEvent.hpp` with `libcxx`, compilation fails. This is because we are not including the `sstream` header.

This commit adds the missing include, allowing `PerfEvent.hpp` to build with `libcxx`.

We ran into this issue while filing:
https://github.com/durner/AnyBlob/pull/3