### PR TITLE
Vertical report format

### DIFF
--- a/PerfEvent.hpp
+++ b/PerfEvent.hpp
@@ -160,24 +160,24 @@ struct PerfEvent {
    }
 
    static void printCounter(std::ostream& headerOut, std::ostream& dataOut, std::string name, std::string counterValue, bool addComma=true) {
-     auto width=std::max(name.length(),counterValue.length());
-     headerOut << std::setw(static_cast<int>(width)) << name << (addComma ? "," : "") << " ";
-     dataOut << std::setw(static_cast<int>(width)) << counterValue << (addComma ? "," : "") << " ";
+      auto width=std::max(name.length(),counterValue.length());
+      headerOut << std::setw(static_cast<int>(width)) << name << (addComma ? "," : "") << " ";
+      dataOut << std::setw(static_cast<int>(width)) << counterValue << (addComma ? "," : "") << " ";
    }
 
    template <typename T>
    static void printCounter(std::ostream& headerOut, std::ostream& dataOut, std::string name, T counterValue, bool addComma=true) {
-     std::stringstream stream;
-     stream << std::fixed << std::setprecision(2) << counterValue;
-     PerfEvent::printCounter(headerOut,dataOut,name,stream.str(),addComma);
+      std::stringstream stream;
+      stream << std::fixed << std::setprecision(2) << counterValue;
+      PerfEvent::printCounter(headerOut,dataOut,name,stream.str(),addComma);
    }
 
    void printReport(std::ostream& out, uint64_t normalizationConstant) {
-     std::stringstream header;
-     std::stringstream data;
-     printReport(header,data,normalizationConstant);
-     out << header.str() << std::endl;
-     out << data.str() << std::endl;
+      std::stringstream header;
+      std::stringstream data;
+      printReport(header,data,normalizationConstant);
+      out << header.str() << std::endl;
+      out << data.str() << std::endl;
    }
 
    void printReport(std::ostream& headerOut, std::ostream& dataOut, uint64_t normalizationConstant) {
@@ -197,21 +197,17 @@ struct PerfEvent {
       printCounter(headerOut,dataOut,"GHz",getGHz(),false);
    }
 
-   static void printCounterVertical(std::ostream& infoOut, std::string name, std::string counterValue, int eNameWidth) {
-     infoOut << std::setw(eNameWidth) << std::left << name << " : " << counterValue << std::endl;
-   }
-
    template <typename T>
    static void printCounterVertical(std::ostream& infoOut, std::string name, T counterValue, int eNameWidth) {
-     std::stringstream stream;
-     stream << std::fixed << std::setprecision(2) << counterValue;
-     PerfEvent::printCounterVertical(infoOut,name,stream.str(),eNameWidth);
+      std::stringstream stream;
+      stream << std::fixed << std::setprecision(2) << counterValue;
+      infoOut << std::setw(eNameWidth) << std::left << name << " : " << stream.str() << std::endl;
    }
 
    void printReportVertical(std::ostream& out, uint64_t normalizationConstant) {
-     std::stringstream info;
-     printReportVerticalUtil(info,normalizationConstant);
-     out << info.str() << std::endl;
+      std::stringstream info;
+      printReportVerticalUtil(info,normalizationConstant);
+      out << info.str() << std::endl;
    }
 
    void printReportVerticalUtil(std::ostream& infoOut, uint64_t normalizationConstant) {
@@ -240,53 +236,53 @@ struct PerfEvent {
 
 struct BenchmarkParameters {
 
-  void setParam(const std::string& name,const std::string& value) {
-    params[name]=value;
-  }
+   void setParam(const std::string& name,const std::string& value) {
+      params[name]=value;
+   }
 
-  void setParam(const std::string& name,const char* value) {
-    params[name]=value;
-  }
+   void setParam(const std::string& name,const char* value) {
+      params[name]=value;
+   }
 
-  template <typename T>
-  void setParam(const std::string& name,T value) {
-    setParam(name,std::to_string(value));
-  }
+   template <typename T>
+   void setParam(const std::string& name,T value) {
+      setParam(name,std::to_string(value));
+   }
 
-  void printParams(std::ostream& header,std::ostream& data) {
-    for (auto& p : params) {
-      PerfEvent::printCounter(header,data,p.first,p.second);
-    }
-  }
+   void printParams(std::ostream& header,std::ostream& data) {
+      for (auto& p : params) {
+         PerfEvent::printCounter(header,data,p.first,p.second);
+      }
+   }
 
-  BenchmarkParameters(std::string name="") {
-    if (name.length())
-      setParam("name",name);
-  }
+   BenchmarkParameters(std::string name="") {
+      if (name.length())
+         setParam("name",name);
+   }
 
-  private:
-  std::map<std::string,std::string> params;
+   private:
+   std::map<std::string,std::string> params;
 };
 
 struct PerfRef {
-    union {
+   union {
       PerfEvent instance;
       PerfEvent *pointer;
-    };
-    bool has_instance;
+   };
+   bool has_instance;
 
-    PerfRef() : instance(), has_instance(true) {}
-    PerfRef(PerfEvent *ptr) : pointer(ptr), has_instance(false) {}
-    PerfRef(const PerfRef&) = delete;
+   PerfRef() : instance(), has_instance(true) {}
+   PerfRef(PerfEvent *ptr) : pointer(ptr), has_instance(false) {}
+   PerfRef(const PerfRef&) = delete;
 
-    ~PerfRef() {
+   ~PerfRef() {
       if (has_instance)
-        instance.~PerfEvent();
-    }
+      instance.~PerfEvent();
+   }
 
-    PerfEvent* operator->() {
-        return has_instance ? &instance : pointer;
-    }
+   PerfEvent* operator->() {
+      return has_instance ? &instance : pointer;
+   }
 };
 
 struct PerfEventBlock {
@@ -311,15 +307,15 @@ struct PerfEventBlock {
    }
 
    ~PerfEventBlock() {
-     e->stopCounters();
-     std::stringstream header;
-     std::stringstream data;
-     parameters.printParams(header,data);
-     PerfEvent::printCounter(header,data,"time sec",e->getDuration());
-     e->printReport(header, data, scale);
-     if (printHeader)
-       std::cout << header.str() << std::endl;
-     std::cout << data.str() << std::endl;
+      e->stopCounters();
+      std::stringstream header;
+      std::stringstream data;
+      parameters.printParams(header,data);
+      PerfEvent::printCounter(header,data,"time sec",e->getDuration());
+      e->printReport(header, data, scale);
+      if (printHeader)
+         std::cout << header.str() << std::endl;
+      std::cout << data.str() << std::endl;
    }
 };
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This prints something like this:
 cycles, instructions, L1-misses, LLC-misses, branch-misses, task-clock,    scale, IPC, CPUs,  GHz
  10.97,     28.01,      0.22,       0.00,          0.00,       3.89, 10000000, 2.55, 1.00, 2.82
 ```
+To print the output vertically, use the function `printReportVertical`.
 
 ### Usage of PerfEventBlock (convenience wrapper):
 


### PR DESCRIPTION
I added a function that allows to print the report in a vertical format, making it easier to read the output on the CLI when many events are measured.